### PR TITLE
Homebrew path is hard-coded to /usr/local

### DIFF
--- a/LaunchRocket/ServiceManager.m
+++ b/LaunchRocket/ServiceManager.m
@@ -86,7 +86,7 @@
     }
     
     
-    NSString *optPath = [NSString stringWithFormat:@"%@/opt", homebrewPath];
+    NSString *optPath = [NSString stringWithFormat:@"%@/opt/", homebrewPath];
     NSFileManager *fm = [[NSFileManager alloc] init];
     NSDirectoryEnumerator *de = [fm enumeratorAtPath:optPath];
     for (NSString *item in de) {


### PR DESCRIPTION
Clicking on "Scan Homebrew" doesn't find any services if you are not using the default homebrew path (i.e. `/usr/local`).

`-handleHomebrewScanClick:` could check if `/usr/local/bin/brew` exists, and if not, just ask the user to point to his homebrew installation.
