### PR TITLE
isStarted check fails on similar service indentifiers

### DIFF
--- a/LaunchRocket/ServiceController.m
+++ b/LaunchRocket/ServiceController.m
@@ -38,8 +38,9 @@
     Process *p = [[Process alloc] init];
     
     NSString *output;
-    NSMutableString *launchCtlCommand = [[NSMutableString alloc] initWithString:@"/bin/launchctl list | grep "];
+    NSMutableString *launchCtlCommand = [[NSMutableString alloc] initWithString:@"/bin/launchctl list | grep \""];
     [launchCtlCommand appendString:self.service.identifier];
+    [launchCtlCommand appendString:@"\"$"];
     
     if (self.service.useSudo) {
         output = [p executeSudo:launchCtlCommand];


### PR DESCRIPTION
I have two services with very similar names:
1. `homebrew.mxcl.solr`
2. `homebrew.mxcl.solr36`

When `homebrew.mxcl.solr36` is started `homebrew.mxcl.solr` will also be reported started no matter what status it has.

I'm pretty sure it's because of the code in `istStarted`:

``` objc
    NSMutableString *launchCtlCommand = [[NSMutableString alloc] initWithString:@"/bin/launchctl list | grep "];
    [launchCtlCommand appendString:self.service.identifier];
```

A grep for `homebrew.mxcl.solr` will of course also match the `homebrew.mxcl.solr36` entry.

Putting word boundary metacharacter around the service identifier will fix this (`\bhomebrew.mxcl.solr\b`).

I'm not really fluent in building with Xcode so no pull requests this time :smile: 

Thank you for a great piece of software!
