### PR TITLE
Remove special cases for josegonzalez/php

### DIFF
--- a/LaunchRocket/ServiceManager.m
+++ b/LaunchRocket/ServiceManager.m
@@ -159,8 +159,7 @@
         }
     }
     
-    NSLog(@"Scanning for josegonzales/php");
-    //handle special plists, most specifically, josegonzales/php stuff
+    NSLog(@"Scanning for special plists");
     NSString *specialPlistPath = [[self bundle] pathForResource:@"special-plists" ofType:@"plist"];
     NSArray *additionalPlists = [NSArray arrayWithContentsOfFile:specialPlistPath];
     for (NSString *plist in additionalPlists) {

--- a/LaunchRocket/special-plists.plist
+++ b/LaunchRocket/special-plists.plist
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<array>
-	<string>php53/homebrew-php.josegonzalez.php53.plist</string>
-	<string>php54/homebrew-php.josegonzalez.php54.plist</string>
-	<string>php55/homebrew-php.josegonzalez.php55.plist</string>
-</array>
+<array/>
 </plist>


### PR DESCRIPTION
This is officially accepted into homebrew now so need to get rid of the special cases looking for plists in the wrong place.
