### PR TITLE
Fixted markdown to properly display the screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Mac PreferencePane for managing services with `launchd`. For an introduction o
 
 Of particular note is the ability to run some services as root. With Homebrew, most services can simply run as the current user, and this is the desired behavior for a development environment. However, some services (dnsmasq) require being bound to privileged ports, and others (nginx, apache) don't require it, but might in some circumstances. For example, many times it's just easier to run Apache on port 80 and 443 than to deal with code that might not like port numbers in the URLs. I recommend you only run things as root if you absolutely must, to get them working properly.
 
-<img src="https://raw2.github.com/jimbojsb/launchrocket/master/screenshots/LaunchRocket.png">
+![LaunchRocke Screenshot](/screenshots/LaunchRocket.png)
 
 Features
 --------


### PR DESCRIPTION
The markdown code for embedding the screenshot was broken.
The correct syntax is `![Alt Text](url)`.