### PR TITLE
Fix 68 - Update service stale name

### DIFF
--- a/LaunchRocket/ServiceManager.m
+++ b/LaunchRocket/ServiceManager.m
@@ -213,12 +213,8 @@
     [dict setObject:plistFile forKey:@"plist"];
     [dict setObject:serviceName forKey:@"name"];
     
-    if ([[self.preferences objectForKey:@"services"] objectForKey:identifier] == nil) {
-        NSLog(@"Adding %@", plistFile);
-        [[self.preferences objectForKey:@"services"] setObject:dict forKey:identifier];
-    } else {
-        NSLog(@"%@ already exists -- preserving", plistFile);
-    }
+	NSLog(@"Adding %@", plistFile);
+	[[self.preferences objectForKey:@"services"] setObject:dict forKey:identifier];
     [self writePreferences];
 }
 

--- a/LaunchRocket/ServiceManager.m
+++ b/LaunchRocket/ServiceManager.m
@@ -213,8 +213,8 @@
     [dict setObject:plistFile forKey:@"plist"];
     [dict setObject:serviceName forKey:@"name"];
     
-	NSLog(@"Adding %@", plistFile);
-	[[self.preferences objectForKey:@"services"] setObject:dict forKey:identifier];
+    NSLog(@"Adding %@", plistFile);
+    [[self.preferences objectForKey:@"services"] setObject:dict forKey:identifier];
     [self writePreferences];
 }
 


### PR DESCRIPTION
Since `self.preferences` is typically either loaded from disk or stored in memory, the only way to refresh the name of a service is to delete `~/Library/Preferences/com.joshbutts.launchrocket.plist` and kill the preference pane process. As a result, even after updating the service name in [baadf3d](https://github.com/jimbojsb/launchrocket/commit/baadf3d5a3e620c04b82a8ff325968226f7e4bf5) the old name is still essentially stuck in `self.preferences`.

This fixes issue [68](https://github.com/jimbojsb/launchrocket/issues/68).